### PR TITLE
✨ Feat: #30 HealthKit 데이터를 WalkingSession으로 변환하는 기능 구현

### DIFF
--- a/NeverDie/NeverDie/Info.plist
+++ b/NeverDie/NeverDie/Info.plist
@@ -6,5 +6,7 @@
 	<array>
 		<string>PretendardVariable.ttf</string>
 	</array>
+	<key>NSHealthShareUsageDescription</key>
+	<string>NeverDie 앱에서 걸음 수 데이터를 읽어와 수명 계산에 활용하기 위해 HealthKit 접근이 필요합니다.</string>
 </dict>
 </plist>

--- a/NeverDie/NeverDie/Models/WalkingSession.swift
+++ b/NeverDie/NeverDie/Models/WalkingSession.swift
@@ -11,63 +11,70 @@ import SwiftData
 // MARK: - 걷기 세션 모델
 @Model
 final class WalkingSession {
-    var startTime: Date
-    var endTime: Date
+    var date: Date          // 날짜 (시간은 00:00:00으로 정규화)
+    var hour: Int           // 시간 (0-23)
     var distance: Double    // 거리 (미터)
     var stepCount: Int      // 걸음 수
     var calories: Double    // 소모 칼로리 (kcal)
-    var routeName: String?  // 경로 이름 (선택사항)
     
     // MARK: - 계산된 속성
+    var startTime: Date {
+        let calendar = Calendar.current
+        return calendar.date(bySettingHour: hour, minute: 0, second: 0, of: date) ?? date
+    }
+    
+    var endTime: Date {
+        return startTime.addingTimeInterval(3600) // 1시간 후
+    }
+    
     var duration: TimeInterval {
-        return endTime.timeIntervalSince(startTime)
+        return 3600 // 1시간 고정
     }
     
     var durationInMinutes: Double {
-        return duration / 60.0
+        return 60.0 // 60분 고정
     }
     
     var averageSpeed: Double {
-        guard duration > 0 else { return 0 }
-        return (distance / 1000) / (duration / 3600) // km/h
+        guard distance > 0 else { return 0 }
+        return (distance / 1000) // km/h (1시간이므로 거리/1000이 곧 속도)
     }
     
     var pace: Double {
         guard distance > 0 else { return 0 }
-        return (duration / 60) / (distance / 1000) // 분/km
+        return 60.0 / (distance / 1000) // 분/km (60분 / km)
     }
     
     // MARK: - 초기화
     init(
-        startTime: Date,
-        endTime: Date,
+        date: Date,
+        hour: Int,
         distance: Double,
         stepCount: Int,
-        calories: Double,
-        routeName: String? = nil
+        calories: Double
     ) {
-        self.startTime = startTime
-        self.endTime = endTime
+        // 날짜를 00:00:00으로 정규화
+        let calendar = Calendar.current
+        self.date = calendar.startOfDay(for: date)
+        self.hour = max(0, min(23, hour)) // 0-23 범위로 제한
         self.distance = distance
         self.stepCount = stepCount
         self.calories = calories
-        self.routeName = routeName
     }
 }
 
 // MARK: - 편의 메서드
 extension WalkingSession {
     static func createSampleSession() -> WalkingSession {
-        let start = Date()
-        let end = start.addingTimeInterval(1800) // 30분 후
+        let now = Date()
+        let currentHour = Calendar.current.component(.hour, from: now)
         
         return WalkingSession(
-            startTime: start,
-            endTime: end,
+            date: now,
+            hour: currentHour,
             distance: 2500.0,    // 2.5km
             stepCount: 3200,     // 3200걸음
-            calories: 180.5,     // 180.5kcal
-            routeName: "집 근처 산책로"
+            calories: 180.5      // 180.5kcal
         )
     }
     
@@ -80,14 +87,7 @@ extension WalkingSession {
     }
     
     var formattedDuration: String {
-        let hours = Int(duration) / 3600
-        let minutes = (Int(duration) % 3600) / 60
-        
-        if hours > 0 {
-            return String(format: "%d시간 %d분", hours, minutes)
-        } else {
-            return String(format: "%d분", minutes)
-        }
+        return "1시간"
     }
     
     var formattedCalories: String {
@@ -102,5 +102,15 @@ extension WalkingSession {
         let minutes = Int(pace)
         let seconds = Int((pace - Double(minutes)) * 60)
         return String(format: "%d'%02d\"/km", minutes, seconds)
+    }
+    
+    var formattedTimeSlot: String {
+        return String(format: "%d시 - %d시", hour, (hour + 1) % 24)
+    }
+    
+    var dateString: String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.string(from: date)
     }
 } 

--- a/NeverDie/NeverDie/Services/HealthKitService.swift
+++ b/NeverDie/NeverDie/Services/HealthKitService.swift
@@ -8,6 +8,7 @@
 import Foundation
 import HealthKit
 import Combine
+import SwiftData
 
 @MainActor
 class HealthKitService: ObservableObject {
@@ -140,6 +141,217 @@ class HealthKitService: ObservableObject {
             group.notify(queue: .main) {
                 continuation.resume(returning: weeklyData)
             }
+        }
+    }
+    
+    // MARK: - HealthKit to WalkingSession 변환
+    
+    /// 특정 날짜의 시간별 걸음 수 데이터를 가져와서 WalkingSession으로 변환
+    func fetchAndConvertDailyWalkingSessions(for date: Date, modelContext: ModelContext) async {
+        let hourlyStepData = await fetchHourlyStepData(for: date)
+        let walkingSessions = convertToWalkingSessions(hourlyStepData: hourlyStepData, date: date)
+        await saveWalkingSessions(walkingSessions, to: modelContext)
+    }
+    
+    /// 특정 날짜의 시간별 걸음 수 데이터 가져오기
+    private func fetchHourlyStepData(for date: Date) async -> [Int: Int] {
+        guard let stepCountType = HKQuantityType.quantityType(forIdentifier: .stepCount) else {
+            return [:]
+        }
+        
+        let calendar = Calendar.current
+        var hourlyData: [Int: Int] = [:]
+        
+        return await withCheckedContinuation { continuation in
+            let group = DispatchGroup()
+            
+            // 24시간 각각에 대해 데이터 가져오기
+            for hour in 0..<24 {
+                group.enter()
+                
+                let hourStart = calendar.date(bySettingHour: hour, minute: 0, second: 0, of: date)!
+                let hourEnd = calendar.date(byAdding: .hour, value: 1, to: hourStart)!
+                
+                let predicate = HKQuery.predicateForSamples(withStart: hourStart, end: hourEnd, options: .strictStartDate)
+                let query = HKStatisticsQuery(
+                    quantityType: stepCountType,
+                    quantitySamplePredicate: predicate,
+                    options: .cumulativeSum
+                ) { _, result, error in
+                    defer { group.leave() }
+                    
+                    guard let result = result, error == nil else { return }
+                    let steps = Int(result.sumQuantity()?.doubleValue(for: HKUnit.count()) ?? 0)
+                    hourlyData[hour] = steps
+                }
+                
+                healthStore.execute(query)
+            }
+            
+            group.notify(queue: .main) {
+                continuation.resume(returning: hourlyData)
+            }
+        }
+    }
+    
+    /// 시간별 걸음 수 데이터를 WalkingSession 배열로 변환
+    private func convertToWalkingSessions(hourlyStepData: [Int: Int], date: Date) -> [WalkingSession] {
+        var sessions: [WalkingSession] = []
+        
+        for (hour, stepCount) in hourlyStepData {
+            // 걸음 수가 0보다 큰 경우에만 세션 생성
+            guard stepCount > 0 else { continue }
+            
+            let distance = estimateDistance(from: stepCount)
+            let calories = estimateCalories(from: stepCount)
+            
+            let session = WalkingSession(
+                date: date,
+                hour: hour,
+                distance: distance,
+                stepCount: stepCount,
+                calories: calories
+            )
+            
+            sessions.append(session)
+        }
+        
+        return sessions
+    }
+    
+    /// 걸음 수로부터 거리 추정 (미터)
+    private func estimateDistance(from stepCount: Int) -> Double {
+        // 평균 보폭을 70cm로 가정
+        let averageStepLength: Double = 0.7 // 미터
+        return Double(stepCount) * averageStepLength
+    }
+    
+    /// 걸음 수로부터 칼로리 추정 (kcal)
+    private func estimateCalories(from stepCount: Int) -> Double {
+        // 걸음당 평균 0.04kcal 소모로 가정
+        let caloriesPerStep: Double = 0.04
+        return Double(stepCount) * caloriesPerStep
+    }
+    
+    /// 특정 날짜와 시간의 기존 WalkingSession 찾기
+    private func findExistingSession(date: Date, hour: Int, in modelContext: ModelContext) throws -> WalkingSession? {
+        let allSessions = try modelContext.fetch(FetchDescriptor<WalkingSession>())
+        return allSessions.first { session in
+            Calendar.current.isDate(session.date, inSameDayAs: date) && session.hour == hour
+        }
+    }
+    
+    /// WalkingSession 배열을 SwiftData에 저장
+    private func saveWalkingSessions(_ sessions: [WalkingSession], to modelContext: ModelContext) async {
+        await MainActor.run {
+            for session in sessions {
+                // 같은 날짜, 같은 시간의 기존 데이터가 있는지 확인
+                do {
+                    let existingSession = try findExistingSession(
+                        date: session.date, 
+                        hour: session.hour, 
+                        in: modelContext
+                    )
+                    
+                    if let existing = existingSession {
+                        // 기존 세션 업데이트
+                        existing.stepCount = session.stepCount
+                        existing.distance = session.distance
+                        existing.calories = session.calories
+                    } else {
+                        // 새 세션 삽입
+                        modelContext.insert(session)
+                    }
+                } catch {
+                    
+                }
+            }
+            
+            // 변경사항 저장
+            do {
+                try modelContext.save()
+            } catch {
+                
+            }
+        }
+    }
+    
+    // MARK: - 테스트 및 디버깅 메서드
+    
+    /// 샘플 WalkingSession 데이터로 저장 테스트
+    func testSaveWalkingSessions(modelContext: ModelContext) async {
+        let today = Date()
+        let sampleSessions = createSampleWalkingSessions(for: today)
+        
+        await saveWalkingSessions(sampleSessions, to: modelContext)
+    }
+    
+    /// 테스트용 샘플 WalkingSession 생성
+    private func createSampleWalkingSessions(for date: Date) -> [WalkingSession] {
+        let sampleData: [(hour: Int, stepCount: Int)] = [
+            (8, 1200),   // 오전 8시: 1200걸음
+            (12, 800),   // 점심 12시: 800걸음
+            (14, 1500),  // 오후 2시: 1500걸음
+            (18, 2000),  // 오후 6시: 2000걸음 (퇴근)
+            (20, 1000)   // 오후 8시: 1000걸음 (저녁산책)
+        ]
+        
+        return sampleData.map { data in
+            WalkingSession(
+                date: date,
+                hour: data.hour,
+                distance: estimateDistance(from: data.stepCount),
+                stepCount: data.stepCount,
+                calories: estimateCalories(from: data.stepCount)
+            )
+        }
+    }
+    
+    /// 특정 날짜의 저장된 WalkingSession 조회 및 출력
+    func printStoredWalkingSessions(for date: Date, modelContext: ModelContext) {
+        do {
+            let allSessions = try modelContext.fetch(FetchDescriptor<WalkingSession>())
+            let filteredSessions = allSessions.filter { session in
+                Calendar.current.isDate(session.date, inSameDayAs: date)
+            }.sorted { $0.hour < $1.hour }
+            
+            print("📊 \(date.formatted(date: .abbreviated, time: .omitted)) 저장된 데이터:")
+            if filteredSessions.isEmpty {
+                print("   데이터 없음")
+            } else {
+                for session in filteredSessions {
+                    print("   \(session.formattedTimeSlot): \(session.stepCount)걸음, \(session.formattedDistance), \(session.formattedCalories)")
+                }
+            }
+        } catch {
+            
+        }
+    }
+    
+    /// 전체 저장된 WalkingSession 개수 확인
+    func getTotalStoredSessionsCount(modelContext: ModelContext) -> Int {
+        let descriptor = FetchDescriptor<WalkingSession>()
+        
+        do {
+            let sessions = try modelContext.fetch(descriptor)
+            return sessions.count
+        } catch {
+            return 0
+        }
+    }
+    
+    /// 모든 저장된 데이터 삭제 (테스트용)
+    func clearAllWalkingSessions(modelContext: ModelContext) {
+        let descriptor = FetchDescriptor<WalkingSession>()
+        
+        do {
+            let sessions = try modelContext.fetch(descriptor)
+            for session in sessions {
+                modelContext.delete(session)
+            }
+            try modelContext.save()
+        } catch {
+            
         }
     }
 } 


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #30 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- WalkingSession 모델 리팩토링: 시간별 저장 구조로 변경 (startTime/endTime → date/hour)
- HealthKit 데이터 변환 로직: 시간별 걸음 수 데이터를 WalkingSession으로 변환하는 기능 구현
- SwiftData 저장 시스템: 중복 처리 및 업데이트 로직 포함한 데이터 저장 기능
- HealthKit 권한 설정: Info.plist 및 entitlements 설정 완료

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

해당 없음 (데이터 모델 및 서비스 로직 구현)

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] WalkingSession 모델의 시간별 데이터 구조 정상 동작
- [x] HealthKit 권한 요청 및 데이터 접근 정상 동작
- [x] 시간별 걸음 수 데이터 조회 및 변환 로직 검증
- [x] SwiftData 저장 및 중복 처리 로직 정상 동작
- [x] 샘플 데이터 생성 및 테스트 메서드 동작 확인

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- 모델 구조 변경: WalkingSession을 1시간 단위 고정 세션으로 변경하여 시간대별 데이터 관리 최적화
- 거리/칼로리 추정: 걸음 수 기반 알고리즘으로 추정값 제공 (보폭 70cm, 걸음당 0.04kcal 가정)
- 중복 데이터 처리: 같은 날짜/시간대 데이터는 업데이트 방식으로 중복 방지
- 테스트 지원: 실제 HealthKit 데이터 외에도 샘플 데이터로 기능 테스트 가능
- 향후 확장성: 다른 건강 데이터 타입 추가 시 동일한 패턴으로 확장 가능

---